### PR TITLE
ci(pages): deploy Vite build to GitHub Pages via official workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy Vite site to GitHub Pages
+on:
+  push: { branches: [main] }
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: ./dist }
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Why
- 合併到 main 後自動建置並部署到 Pages

Changes
- 新增 .github/workflows/deploy.yml（build → upload artifact → deploy）

QA
- 合併後 Actions 兩個 job（build→deploy）皆綠燈
- Settings → Pages 設定為 GitHub Actions
- 部署網址可正常存取，靜態資源路徑為 /Portfolio/assets/...（Vite base='/Portfolio/'）
