### PR TITLE
chore: public-ready portfolio (contacts/hero) + fix Vite base for Pages

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -34,12 +34,7 @@ const Contact: React.FC = () => {
       content: "tinahuu321@gmail.com",
       link: "mailto:tinahuu321@gmail.com",
     },
-    // {
-    //   icon: <Phone size={24} />,
-    //   title: "電話",
-    //   content: "+886 912 345 678",
-    //   link: "tel:+886912345678",
-    // },
+   
     {
       icon: <MapPin size={24} />,
       title: "位置",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC = () => {
     },
     {
       icon: <Linkedin size={20} />,
-      href: "https://linkedin.com",
+      href: "https://www.linkedin.com/in/tina-hu-frontend/",
       label: "LinkedIn",
     },
     {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -14,11 +14,12 @@ const Hero: React.FC = () => {
     <section
       id="home"
       className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand-start to-brand-end"
+      aria-labelledby="hero-title"
     >
-      <div className="container-max section-padding  pt-10 md:pt-13 text-center">
+      <div className="container-max section-padding pt-10 md:pt-12 text-center">
         <div className="max-w-4xl mx-auto">
           {/* Profile Image */}
-          <div className="my-6 ">
+          <div className="my-6">
             <div className="relative w-32 h-32 mx-auto rounded-full overflow-hidden ring-2 ring-rose-100 shadow">
               <img
                 src={profileImg}
@@ -34,7 +35,10 @@ const Hero: React.FC = () => {
           </div>
 
           {/* Main Content */}
-          <h1 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6">
+          <h1
+            id="hero-title"
+            className="text-4xl md:text-6xl font-bold text-gray-900 mb-6"
+          >
             你好，我是
             <span className="text-primary-600 block mt-2">
               前端工程師 Tina Hu
@@ -51,10 +55,18 @@ const Hero: React.FC = () => {
 
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-            <a href="#projects" className="btn-primary">
+            <a
+              href="#projects"
+              className="btn-primary"
+              aria-label="查看我的專案作品"
+            >
               查看專案作品
             </a>
-            <a href="#contact" className="btn-secondary">
+            <a
+              href="#contact"
+              className="btn-secondary"
+              aria-label="前往聯絡方式"
+            >
               聯絡我
             </a>
           </div>
@@ -62,51 +74,56 @@ const Hero: React.FC = () => {
           {/* Social Links */}
           <div className="flex justify-center space-x-6 mb-10">
             <a
-              href="https://github.com/yuting813/mern-project"
+              href="https://github.com/yuting813"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"
               className="text-gray-600 hover:text-primary-600 transition-colors"
               title="GitHub"
             >
-              <Github size={24} />
+              <Github size={24} aria-hidden="true" />
             </a>
 
             <a
-              href="https://linkedin.com" // 之後換成你的實際 LinkedIn
-              target="_blank" // ✅ 新分頁開啟
-              rel="noopener noreferrer" // ✅ 安全屬性
+              href="https://www.linkedin.com/in/tina-hu-frontend/"
+              target="_blank"
+              rel="noopener noreferrer"
               aria-label="LinkedIn"
               className="text-gray-600 hover:text-primary-600 transition-colors"
               title="LinkedIn"
             >
-              <Linkedin size={24} />
+              <Linkedin size={24} aria-hidden="true" />
             </a>
 
             <a
               href="mailto:tinahuu321@gmail.com"
-              target="_blank"
-              rel="noopener noreferrer"
               aria-label="Email"
               className="text-gray-600 hover:text-primary-600 transition-colors"
               title="Email"
             >
-              <Mail size={24} />
+              <Mail size={24} aria-hidden="true" />
             </a>
           </div>
 
           {/* Scroll Indicator */}
-          <div
-            className="animate-bounce cursor-pointer hover:text-primary-500 transition-colors"
+          <button
+            type="button"
+            className="mx-auto block motion-safe:animate-bounce hover:text-primary-500 transition-colors"
             onClick={scrollToNextSection}
-            role="button"
-            aria-label="向下滾動"
+            aria-label="向下滾動到關於我"
           >
             <ChevronDown
               size={32}
-              className="text-gray-400 mx-auto hover:text-primary-500"
+              className="text-gray-400 hover:text-primary-500"
+              aria-hidden="true"
             />
-          </div>
+          </button>
+          {/* 對減少動作使用者停用動畫 */}
+          <style>{`
+            @media (prefers-reduced-motion: reduce) {
+              .motion-safe\\:animate-bounce { animation: none !important; }
+            }
+          `}</style>
         </div>
       </div>
     </section>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,10 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig(({ mode }) => ({
   plugins: [react()],
-  base: mode === "production" ? "/protfolix/" : "/", // dev 用根目錄、prod 用子路徑
+  base: mode === "production" ? "/portfolio/" : "/", // dev 用根目錄、prod 用子路徑
   build: {
     outDir: "dist",
     assetsDir: "assets",
     sourcemap: false,
-    // minify: "terser",
   },
 }));


### PR DESCRIPTION
## What
- build: Vite base 設為 '/portfolio/'（修正先前錯字，確保 GitHub Pages 正確載入 assets）
- hero: 修正間距（md:pt-*）、補 CTA aria-label、保留首屏圖的 width/height 與 fetchPriority
- contact/footer: 更新 Email/GitHub/LinkedIn 連結，移除 placeholder

## Why
- 準備開啟 LinkedIn「Open to Work」與公開作品集，避免假資料與資產路徑錯誤
- 提升 a11y（鍵盤/讀屏）與首屏穩定度（避免 CLS）

## How to Test
1. 本地開發：`npm run dev` 檢查所有圖片/連結正常
2. 生產預覽：`npm run build && npm run preview`
   - 檢查輸出的 HTML 內資產連結帶有 `/portfolio/`
   - 首屏圖片無抖動、CTA 能正確捲動至 #projects/#contact
3. 部署到 GitHub Pages 後，從 `https://<username>.github.io/portfolio/` 測試：
   - 重新整理/深連結（直接貼 `/portfolio/#projects`）都能正常顯示
